### PR TITLE
feat: Add fxmanifest.lua and LICENSE to initialize project structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2025 BPTNetwork
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to:
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+📌 Contributing Notice:
+By submitting a contribution (code, documentation, or other materials), you agree
+to license your contribution under the same MIT License and allow it to be freely
+used within the BPTNetwork project and its derivatives. Contributions must comply
+with the coding and quality standards defined by the maintainers.
+
+📌 Attribution Notice:
+All original work must retain proper attribution to BPTNetwork. If this resource is
+included in a larger package, credit must be clearly visible in documentation or
+README.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,29 @@
+# 🔧 ResourceName (replace)
+
+> 🧩 A short description of what the resource does.
+
+---
+
+## 📦 Features
+
+- ✅ List main features
+- 🔐 Specify any protections / logs / events used
+- 📂 Framework compatibility (ESX, QBCore, etc.)
+
+---
+
+## ⚙️ Installation
+
+1. Clone or download the resource in `resources/[bpt]/ResourceName`
+2. Add `ensure ResourceName` to `server.cfg`
+3. Configure `shared/config.lua` if present
+
+---
+
+## 🧪 Requirements
+
+---
+
+## 📄 License
+
+> This resource is released under the MIT license.


### PR DESCRIPTION
This pull request introduces the initial structural files for this resource repository:

- fxmanifest.lua: Defines metadata, dependencies, and script loading instructions for the FiveM runtime. This file is essential for the resource to be recognized and executed correctly by the server.

- LICENSE: Adds the MIT license to clearly define usage permissions and contribution terms. It ensures that the project is open for community use and contributions while maintaining legal attribution to the original authors.

These additions lay the foundation for all future development and standardize resource setup across the BPTNetwork organization.